### PR TITLE
Provide item indices to equalFn

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ function arrayDiff(before, after, equalFn) {
     var beforeItem = before[beforeIndex];
     for (var afterIndex = 0; afterIndex < afterLength; afterIndex++) {
       if (afterMarked[afterIndex]) continue;
-      if (!equalFn(beforeItem, after[afterIndex])) continue;
+      if (!equalFn(beforeItem, after[afterIndex], beforeIndex, afterIndex)) continue;
       var from = beforeIndex;
       var to = afterIndex;
       var howMany = 0;
@@ -82,7 +82,7 @@ function arrayDiff(before, after, equalFn) {
       } while (
         beforeIndex < beforeLength &&
         afterIndex < afterLength &&
-        equalFn(before[beforeIndex], after[afterIndex]) &&
+        equalFn(before[beforeIndex], after[afterIndex], beforeIndex, afterIndex) &&
         !afterMarked[afterIndex]
       );
       moves.push(new MoveDiff(from, to, howMany));

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ function arrayDiff(before, after, equalFn) {
   // as moves. Many of these "moves" may end up being discarded in the last
   // pass if they are from an index to the same index, but we don't know this
   // up front, since we haven't yet offset the indices.
-  // 
+  //
   // Also keep a map of all the indices accounted for in the before and after
   // arrays. These maps are used next to create insert and remove diffs.
   var beforeLength = before.length;

--- a/test/test.mocha.coffee
+++ b/test/test.mocha.coffee
@@ -51,6 +51,14 @@ describe 'arrayDiff', ->
     testDiff before, after, (a, b) ->
       return a.id is b.id
 
+  it 'provides the item indices to the equality function', ->
+    before = [{id: 1}, {id: 2}, {id: 6}]
+    after = [{id: 1}, {id: 3}, {id: 4}, {id: 5}]
+    testDiff before, after, (a, b, aIndex, bIndex) ->
+      expect(aIndex).to.be before.indexOf(a)
+      expect(bIndex).to.be after.indexOf(b)
+      return a.id is b.id
+
   it 'diffs randomly rearranged arrays of numbers', ->
     i = 1000
     while i--


### PR DESCRIPTION
Allows the caller to memoize the results in case deciding equality is expensive.

This makes arraydiff symmetrical with its async sister module again:
bruderstein/arraydiff-async@a63028c
